### PR TITLE
Export `ObjectEqualsOptions`

### DIFF
--- a/src/objectEquals.d.mts
+++ b/src/objectEquals.d.mts
@@ -1,4 +1,4 @@
-interface ObjectEqualsOptions {
+export interface ObjectEqualsOptions {
     /**
      * Enable circular reference handling using a cache.
      * @default false


### PR DESCRIPTION
Make this type accessible to consumers.